### PR TITLE
Implement event `id` attribute, ui tweaks, renderer changes

### DIFF
--- a/src/panel/scenario/generators/events/Event.tsx
+++ b/src/panel/scenario/generators/events/Event.tsx
@@ -14,10 +14,12 @@ import {Tab, Tabs} from 'react-bootstrap';
 
 // elemental components
 import TabTitle from '~/components/ui/TabTitle';
+import Accordion from '~/components/ui/Accordion';
 import Action from '~/components/scenario/generic/Action';
 import Condition from '~/components/scenario/generic/Condition';
 
 // components
+import EventId from './elements/EventId';
 import FlagsDropdown from './elements/FlagsDropdown';
 import ActionDropdown from './elements/ActionDropdown';
 import ConditionDropdown from './elements/ConditionDropdown';
@@ -66,9 +68,10 @@ export interface EventState extends Omit<EventType, 'actions'> {
 }
 
 export const changedValuesToEventValues = (data: EventState): EventType => {
-  const {flags, condition, actions} = data;
+  const {flags, condition, actions, id = ''} = data;
 
   return {
+    id,
     flags,
     condition,
     actions: Object.values(actions),
@@ -82,6 +85,7 @@ const Event = (props: Props) => {
   const [actionActiveKey, setActionActiveKey] = React.useState<string>('');
 
   const valuer = useValues<EventState>(merge({
+    id: '',
     flags: [],
     condition: {} as AnyCondition,
     actions: {},
@@ -91,12 +95,10 @@ const Event = (props: Props) => {
     disabled: boolean;
     disabledCheckbox: boolean;
     actionsExpanded: boolean;
-    flagsExpanded: boolean;
   }>({
     disabled: newProps.disabled,
     disabledCheckbox: newProps.disabledCheckbox,
     actionsExpanded: true,
-    flagsExpanded: false,
   });
 
   //<editor-fold desc="Reflect values changes">
@@ -193,17 +195,24 @@ const Event = (props: Props) => {
   return (
     <div className={cn('mt-0 checkbox-align', {'text-muted': isDisabled})}>
       <div className="pt-2 pl-3 pr-3 pb-2 mt-2 mb-1">
+        <Accordion
+          noBodyPad={true}
+          noCard={true}
+          header="Optional parameters"
+          eventKey="clear_trees_optional_parameters">
+        <EventId
+          disabled={isDisabled}
+          value={valuer.get('id', '')}
+          onChange={value => valuer.set('id', value as string)}/>
         <FlagsDropdown
-          expanded={meta.data.flagsExpanded}
-          onCaptionClick={() => {
-            meta.set('flagsExpanded', current => !current);
-          }}
           value={valuer.get('flags', [])}
           disabled={isDisabled}
           onChange={(flags: string[]) => {
             valuer.overwrite('flags', flags);
           }}
         />
+        </Accordion>
+        <div className="mb-3"></div>
 
         {!hasCondition && (
           <ConditionDropdown

--- a/src/panel/scenario/generators/events/elements/EventId.tsx
+++ b/src/panel/scenario/generators/events/elements/EventId.tsx
@@ -1,0 +1,60 @@
+/**
+ * @author Junaid Atari <mj.atari@gmail.com>
+ * @see https://github.com/blacksmoke26/dawn-of-man-generator
+ * @since 2024-06-23
+ * @version 2.4
+ */
+
+import React from 'react';
+import merge from 'deepmerge';
+import {Col, Row} from 'react-bootstrap';
+
+// elemental components
+import TextInput from '~/components/ui/TextInput';
+import PropertyLabel from '~/components/ui/PropertyLabel';
+
+// icons
+import {IconEvent} from '~/components/icons/app';
+
+// types
+import type {Required} from 'utility-types';
+
+export interface Props {
+  disabled?: boolean;
+  value?: string;
+  onChange?(value: string): void;
+}
+
+/** FlagsDropdown functional component */
+const EventId = (props: Props = {}) => {
+  const newProps = merge<Required<Props>>({
+    disabled: false,
+    value: '',
+    onChange() {
+    },
+  }, props);
+
+  return (
+    <div className="mb-2">
+      <Row className="mt-2">
+        <PropertyLabel
+          colProps={{sm: 1, style: {marginTop: 1}}}
+          caption="ID"
+          disabled={props.disabled}
+        />
+        <Col sm={6}>
+          <TextInput
+            caseType="SNAKE_CASE"
+            disabled={newProps.disabled}
+            maxLength={50}
+            allowClear
+            value={newProps.value}
+            placeholder="e.g., back_to_game"
+            onChange={value => newProps.onChange(value as string)}/>
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export default EventId;

--- a/src/panel/scenario/generators/events/elements/FlagsDropdown.tsx
+++ b/src/panel/scenario/generators/events/elements/FlagsDropdown.tsx
@@ -8,118 +8,68 @@
 import React from 'react';
 import merge from 'deepmerge';
 import {capitalCase} from 'change-case';
-import {Row, Col, Button} from 'react-bootstrap';
+import {Row} from 'react-bootstrap';
 
 // elemental components
+import PropertyLabel from '~/components/ui/PropertyLabel';
 import AttributeSelect, {Option} from '~/components/ui/elements/AttributeSelect';
 
 // icons
-import {IconChevronSimpleDown, IconChevronSimpleUp, IconFlag} from '~/components/icons/app';
+import {IconFlag} from '~/components/icons/app';
 
 // utils
 import {EVENT_FLAGS_OPTIONS} from '~/utils/event';
 
 // types
 import type {Required} from 'utility-types';
-import cn from 'classname';
-import {RemoveButton} from '~/components/scenario/conditions/elements/condition-logical';
 
 export interface Props {
   disabled?: boolean;
-  expanded?: boolean;
   value?: string[];
 
   onChange?(items: string[]): void;
-
-  onCaptionClick?(): void;
 }
 
 /** FlagsDropdown functional component */
 const FlagsDropdown = (props: Props = {}) => {
   const newProps = merge<Required<Props>>({
     disabled: false,
-    expanded: true,
     value: [],
     onChange() {
     },
-    onCaptionClick() {
-    },
   }, props);
-  const [expanded, setExpanded] = React.useState<boolean>(newProps.expanded);
-
-
-  React.useEffect(() => {
-    props?.expanded !== undefined && setExpanded(props.expanded);
-  }, [props?.expanded]);
 
   return (
-    <div className="mb-3">
-      <Row>
-        <Col sm="6" className="cursor-pointer" onClick={() => newProps.onCaptionClick()}>
-          <div>
-            <IconFlag width="16" height="16"/> {' '} Flags
-          </div>
-        </Col>
-        <Col col="6" className="text-right" style={{top: 3}}>
-          <div className="d-inline-block">
-            <strong
-              style={{color: '#ebeaea'}}
-              className={cn('text-size-sm', {'text-muted': newProps.disabled})}>
-              <span className="position-relative" style={{top: '0.01rem'}}>
-                {newProps.value.length || <>&nbsp;</>}
-              </span>
-            </strong>
-          </div>
-          <div className="d-inline-block ml-2">
-            <Button
-              variant="link" className="p-0" style={{top: '-0.080rem'}}
-              disabled={newProps.disabled}
-              onClick={() => {
-                newProps.onCaptionClick();
-              }}>
-              {!expanded
-                ? <IconChevronSimpleUp width="16" height="16"/>
-                : <IconChevronSimpleDown width="16" height="16"/>}
-            </Button>
-          </div>
-          <RemoveButton
-            disabled={newProps.disabled}
-            buttonProps={{
-              title: 'Remove all flags',
-            }}
-            onClick={e => {
-              e.stopPropagation();
-              e.preventDefault();
-              newProps?.onChange([]);
-            }}/>
-        </Col>
+    <>
+      <Row className="mt-2">
+        <PropertyLabel
+          colProps={{sm: 1, style: {marginTop: 4}}}
+          caption={(<><IconFlag width="16" height="16"/> {' '} Flags</>)}
+          disabled={props.disabled}
+        />
+        <AttributeSelect
+          className="w-75"
+          colProps={{sm: 8}}
+          disabled={newProps.disabled}
+          options={EVENT_FLAGS_OPTIONS}
+          value={newProps?.value?.map(value => ({value, label: capitalCase(value)})) || []}
+          selectProps={{
+            isSearchable: false, isMulti: true,
+            placeholder: 'Choose flags...',
+            formatOptionLabel: (option: Option | any) => (
+              <><IconFlag width="17" height="17"/>{' '} {option?.label}</>
+            ),
+          }}
+          onChange={(option, {action}) => {
+            if (['select-option', 'remove-value', 'clear'].includes(action) && Array.isArray(option)) {
+              newProps?.onChange(option?.map(({value}) => value) || []);
+            }
+          }}
+          allowClear
+          onClear={() => newProps?.onChange([])}
+        />
       </Row>
-      {expanded && (
-        <Row className="mt-2">
-          <AttributeSelect
-            className="w-75"
-            colProps={{sm: '10'}}
-            disabled={newProps.disabled}
-            options={EVENT_FLAGS_OPTIONS}
-            value={newProps?.value?.map(value => ({value, label: capitalCase(value)})) || []}
-            selectProps={{
-              isSearchable: true, isMulti: true,
-              placeholder: 'Choose flags...',
-              formatOptionLabel: (option: Option | any) => (
-                <><IconFlag width="17" height="17"/>{' '} {option?.label}</>
-              ),
-            }}
-            onChange={(option, {action}) => {
-              if (['select-option', 'remove-value', 'clear'].includes(action) && Array.isArray(option)) {
-                newProps?.onChange(option?.map(({value}) => value) || []);
-              }
-            }}
-            allowClear
-            onClear={() => newProps?.onChange([])}
-          />
-        </Row>
-      )}
-    </div>
+    </>
   );
 };
 

--- a/src/utils/action.ts
+++ b/src/utils/action.ts
@@ -132,6 +132,7 @@ export const PROMINENT_ACTIONS_NAME: ActionName[] = [
   'SetGameplayFlags',
   'SetKnowledgeParameters',
   'SetMigrationParameters',
+  'Spawn',
   'SetRaider',
   'SetTraderPeriod',
 ] as const;

--- a/src/utils/parser/templates-event.ts
+++ b/src/utils/parser/templates-event.ts
@@ -22,6 +22,9 @@ export const toEventTemplate = (attributes: EventType, disabled: boolean = false
 
   const eventProps: string[] = [];
 
+  attributes?.id?.length
+  && eventProps.push(`id="${attributes?.id}"`);
+
   attributes?.flags?.length
   && eventProps.push(`flags="${attributes?.flags?.join(',')}"`);
 


### PR DESCRIPTION
### What's changed?
* Event Editor `ID` input field. `[ui]`
* Grouped optional attributes (`ID` and `Flags`), hidden by default. `[ui]`
* The `event` template now includes the `id` attribute. `[renderar]`
* Make the `Spawn` action prominent in the `Actions dropdown`. `[ui]`